### PR TITLE
added debhelper package requirement for ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,5 @@ automirror can be configured via environment variables:
 Please add test cases under `testdata` for everything you want to have covered.
 
 To build automirror simply run `make deb`, otherwise you can simply run `automirror.sh` from the source distribution.
-Build Requirements are debuild(1), git-dch(1) and [ronn](http://rtomayko.github.io/ronn/). For Ubuntu/Debian install the `devscripts git-buildpackage ruby-ronn make` packages.
+Build Requirements are debuild(1), git-dch(1) and [ronn](http://rtomayko.github.io/ronn/). For Ubuntu/Debian install the `devscripts git-buildpackage ruby-ronn make debhelper` packages.
 


### PR DESCRIPTION
The package was missing on my relatively pristine 14.04LTS and caused the build
to fail on my new notebook. I had all the packages mentioned in the readme already installed, but had to manually install `debhelper` for `make deb` to succeed.
