### PR TITLE
Allow periods in display names

### DIFF
--- a/automirror.sh
+++ b/automirror.sh
@@ -48,7 +48,7 @@ connected_displays=( $(sed -n -e 's/^\(.*\) connected.*mm$/\1/p' <<<"$xrandr_cur
 # display_list is a list of displays with their maximum/optimum pixel and physical dimensions
 # (thanks to the first sed I know that here is only a SINGLE space)
 #                                                                                                                                          |
-display_list="$(sed ':a;N;$!ba;s/\n   / /g' <<<"$xrandr_current" | sed -n -e 's/^\([a-zA-Z0-9_-]\+\) connected.* \([0-9]\+\)mm.* \([0-9]\+\)mm \([0-9]\+\)x\([0-9]\+\).*$/\1 \2 \3 \4 \5/p' )"
+display_list="$(sed ':a;N;$!ba;s/\n   / /g' <<<"$xrandr_current" | sed -n -e 's/^\([a-zA-Z0-9_.-]\+\) connected.* \([0-9]\+\)mm.* \([0-9]\+\)mm \([0-9]\+\)x\([0-9]\+\).*$/\1 \2 \3 \4 \5/p' )"
 : connected_displays: ${connected_displays[@]}
 : display_list: "$display_list"
 

--- a/testdata/plain/dock-and-laptop.txt
+++ b/testdata/plain/dock-and-laptop.txt
@@ -1,0 +1,90 @@
+Screen 0: minimum 8 x 8, current 1920 x 1200, maximum 32767 x 32767
+DP-0.1 connected primary 1920x1200+0+0 (normal left inverted right x axis y axis) 518mm x 324mm
+   1920x1200     59.95*+  59.88  
+   1920x1080     60.00  
+   1680x1050     59.95  
+   1600x1200     60.00  
+   1600x900      60.00  
+   1440x900      59.89  
+   1280x1024     60.02  
+   1280x800      59.81  
+   1024x768      60.00  
+   800x600       60.32  
+   640x480       59.94  
+DP-0 disconnected (normal left inverted right x axis y axis)
+DP-1 disconnected (normal left inverted right x axis y axis)
+HDMI-0 disconnected (normal left inverted right x axis y axis)
+eDP-1-1 connected 1920x1200+0+0 (normal left inverted right x axis y axis) 344mm x 193mm
+   1920x1080     60.01*+  60.01    59.97    59.96    59.93    40.00  
+   1680x1050     59.95    59.88  
+   1600x1024     60.17  
+   1400x1050     59.98  
+   1600x900      59.99    59.94    59.95    59.82  
+   1280x1024     60.02  
+   1440x900      59.89  
+   1400x900      59.96    59.88  
+   1280x960      60.00  
+   1440x810      60.00    59.97  
+   1368x768      59.88    59.85  
+   1360x768      59.80    59.96  
+   1280x800      59.99    59.97    59.81    59.91  
+   1152x864      60.00  
+   1280x720      60.00    59.99    59.86    59.74  
+   1024x768      60.04    60.00  
+   960x720       60.00  
+   928x696       60.05  
+   896x672       60.01  
+   1024x576      59.95    59.96    59.90    59.82  
+   960x600       59.93    60.00  
+   960x540       59.96    59.99    59.63    59.82  
+   800x600       60.00    60.32    56.25  
+   840x525       60.01    59.88  
+   864x486       59.92    59.57  
+   800x512       60.17  
+   700x525       59.98  
+   800x450       59.95    59.82  
+   640x512       60.02  
+   720x450       59.89  
+   700x450       59.96    59.88  
+   640x480       60.00    59.94  
+   720x405       59.51    58.99  
+   684x384       59.88    59.85  
+   680x384       59.80    59.96  
+   640x400       59.88    59.98  
+   576x432       60.06  
+   640x360       59.86    59.83    59.84    59.32  
+   512x384       60.00  
+   512x288       60.00    59.92  
+   480x270       59.63    59.82  
+   400x300       60.32    56.34  
+   432x243       59.92    59.57  
+   320x240       60.05  
+   360x202       59.51    59.13  
+   320x180       59.84    59.32  
+DP-1-1 disconnected (normal left inverted right x axis y axis)
+HDMI-1-1 disconnected (normal left inverted right x axis y axis)
+DP-1-2 disconnected (normal left inverted right x axis y axis)
+HDMI-1-2 disconnected (normal left inverted right x axis y axis)
+HDMI-1-3 disconnected (normal left inverted right x axis y axis)
+DP-1-1-1 disconnected (normal left inverted right x axis y axis)
+  1680x1050 (0x221) 146.250MHz -HSync +VSync
+        h: width  1680 start 1784 end 1960 total 2240 skew    0 clock  65.29KHz
+        v: height 1050 start 1053 end 1059 total 1089           clock  59.95Hz
+  1280x1024 (0x225) 108.000MHz +HSync +VSync
+        h: width  1280 start 1328 end 1440 total 1688 skew    0 clock  63.98KHz
+        v: height 1024 start 1025 end 1028 total 1066           clock  60.02Hz
+  1440x900 (0x224) 106.500MHz -HSync +VSync
+        h: width  1440 start 1520 end 1672 total 1904 skew    0 clock  55.93KHz
+        v: height  900 start  903 end  909 total  934           clock  59.89Hz
+  1280x800 (0x226) 83.500MHz -HSync +VSync
+        h: width  1280 start 1352 end 1480 total 1680 skew    0 clock  49.70KHz
+        v: height  800 start  803 end  809 total  831           clock  59.81Hz
+  1024x768 (0x227) 65.000MHz -HSync -VSync
+        h: width  1024 start 1048 end 1184 total 1344 skew    0 clock  48.36KHz
+        v: height  768 start  771 end  777 total  806           clock  60.00Hz
+  800x600 (0x228) 40.000MHz +HSync +VSync
+        h: width   800 start  840 end  968 total 1056 skew    0 clock  37.88KHz
+        v: height  600 start  601 end  605 total  628           clock  60.32Hz
+  640x480 (0x229) 25.175MHz -HSync -VSync
+        h: width   640 start  656 end  752 total  800 skew    0 clock  31.47KHz
+        v: height  480 start  490 end  492 total  525           clock  59.94Hz

--- a/testdata/plain/dock-and-laptop_result.txt
+++ b/testdata/plain/dock-and-laptop_result.txt
@@ -1,0 +1,2 @@
+--output eDP-1-1 --scale 1x1 --off
+--fb 1920x1200 --output DP-0.1 --mode 1920x1200 --scale 1x1 --output eDP-1-1 --same-as DP-0.1 --mode 1920x1080 --scale-from 1920x1200


### PR DESCRIPTION
Great script! I noticed that one of my monitors doesn't get listed because the regex doesn't catch a period in the display name